### PR TITLE
confirm behavior related to rewrite and return

### DIFF
--- a/proxy-httpbin/conf.d/default.conf
+++ b/proxy-httpbin/conf.d/default.conf
@@ -66,6 +66,22 @@ server {
         return 200 'OK';
     }
 
+    location /rewrite_break_if_return {
+        rewrite .* /get break;
+        if ($http_hoge != "hogehoge") {
+            return 403;
+        }
+        proxy_pass https://httpbin.org;
+    }
+
+    location /if_return_rewrite_break {
+        if ($http_hoge != "hogehoge") {
+            return 403;
+        }
+        rewrite .* /get break;
+        proxy_pass https://httpbin.org;
+    }
+
     location / {
         proxy_pass https://httpbin.org;
     }


### PR DESCRIPTION
`if` and `return` directives are included in [ngx_http_rewrite_module](http://nginx.org/en/docs/http/ngx_http_rewrite_module.html), so if `rewrite … break;` is called before `if` and `return`, these `if` and `return` will be ignored.

(from NGINX document)
> break
stops processing the current set of ngx_http_rewrite_module directives as with the [break](http://nginx.org/en/docs/http/ngx_http_rewrite_module.html#break) directive;
```
$ curl -I http://localhost:8083/if_return_rewrite_break
HTTP/1.1 403 Forbidden

$ curl -I http://localhost:8083/rewrite_break_if_return
HTTP/1.1 200 OK
```